### PR TITLE
Add list class and ol/ul option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ The `toc` array you pass in `showdownToc` will be:
 ]
 ```
 
+The table of contents will output by default as an ordered list `<ol>`. You can change this to an unordered list `<ul>` by passing in a second parameter of options:
+
+```javascript
+const content = 'your markdown content';
+const toc = [];
+const opts = { listType: 'ul' };
+const showdown = new Showdown.Converter({ extensions: [showdownToc({ toc, opts })] });
+const result = showdown.makeHtml(content);
+return result;
+```
+
 ### 2. output table of contents into your html string
 In your markdown just put a [toc] where you want a Table of Contents to appear. This extension will look for the first header after the [toc] and use whatever it finds first as the element for the rest of the TOC.
 

--- a/package.json
+++ b/package.json
@@ -34,18 +34,6 @@
     "lint:ts": "eslint --cache --format=pretty **/*.ts",
     "test": "father test"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "**/*.{ts,json}": [
-      "prettier --write",
-      "git add"
-    ],
-    "**/*.ts": "npm run lint-staged:ts"
-  },
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/showdown": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -1,23 +1,39 @@
 {
   "name": "showdown-toc",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A showdown extension to output toc info.",
+  "keywords": [
+    "showdown-extension",
+    "showdown",
+    "markdown",
+    "markdown-toc"
+  ],
+  "homepage": "https://github.com/ahungrynoob/showdown-toc#readme",
+  "bugs": {
+    "url": "https://github.com/ahungrynoob/showdown-toc/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ahungrynoob/showdown-toc.git"
+  },
+  "license": "MIT",
+  "author": "ahungrynoob",
   "main": "dist/index.js",
   "unpkg": "dist/index.umd.min.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "father build",
-    "test": "father test",
     "ci": "father test --coverage",
     "lint-staged": "lint-staged",
     "lint-staged:ts": "eslint --ext .ts,.tsx",
     "lint:fix": "eslint --fix --cache --format=pretty **/*.ts",
-    "lint:ts": "eslint --cache --format=pretty **/*.ts"
+    "lint:ts": "eslint --cache --format=pretty **/*.ts",
+    "test": "father test"
   },
-  "files": [
-    "dist"
-  ],
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"
@@ -30,22 +46,6 @@
     ],
     "**/*.ts": "npm run lint-staged:ts"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ahungrynoob/showdown-toc.git"
-  },
-  "keywords": [
-    "showdown-extension",
-    "showdown",
-    "markdown",
-    "markdown-toc"
-  ],
-  "author": "ahungrynoob",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/ahungrynoob/showdown-toc/issues"
-  },
-  "homepage": "https://github.com/ahungrynoob/showdown-toc#readme",
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/showdown": "^1.9.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,11 @@ type MetaInfo =
       text: string;
     };
 
-function showdownToc({ toc }: { toc?: TocItem[] } = {}) {
+type TocOpts = {
+  listType: 'ol' | 'ul';
+};
+
+function showdownToc({ toc, opts }: { toc?: TocItem[]; opts?: TocOpts } = {}) {
   return () => [
     {
       type: 'output',
@@ -70,9 +74,10 @@ function showdownToc({ toc }: { toc?: TocItem[] } = {}) {
         source = source.replace(/<p>\[toc\]<\/p>[\n]*/g, () => {
           const headers = tocCollection.shift();
           if (headers && headers.length) {
-            const str = `<ol>${headers
+            const listType = opts?.listType || 'ol';
+            const str = `<${listType} class="showdown-toc">${headers
               .map(({ text, anchor }) => `<li><a href="#${anchor}">${text}</a></li>`)
-              .join('')}</ol>\n`;
+              .join('')}</${listType}>\n`;
             return str;
           }
           return '';

--- a/test/fixtures/toc-ul-in-markdown/index.md
+++ b/test/fixtures/toc-ul-in-markdown/index.md
@@ -1,0 +1,37 @@
+# Main Page Heading
+This is the intro to the main page.
+
+## Section 1
+A story.
+
+[toc]
+
+[toc]
+
+### Part 1
+It was a nice day.
+
+### Part 2
+There were stormy clouds on the horizon.
+
+#### Part 2A
+They were very dark.
+
+### Part 3
+Then it rained.
+
+## Section 2
+Notice the section 2 header above is not included in the TOC of section 1? That's because each toc tag assumes it should stay in it's own section.
+
+[toc]
+
+### Part 1
+
+### Part 2
+
+#### Part 2A
+Notice this heading isn't in the contents above. We only index the top level headings in each section, to keep things tidy. You may or may not like this, but that's the way it is. If you want to create a pull request with an option, you're welcome to! :)
+
+### Part 3
+
+The End.

--- a/test/fixtures/toc-ul-in-markdown/index.output
+++ b/test/fixtures/toc-ul-in-markdown/index.output
@@ -2,7 +2,7 @@
 <p>This is the intro to the main page.</p>
 <h2 id="section-1">Section 1</h2>
 <p>A story.</p>
-<ol class="showdown-toc"><li><a href="#part-1">Part 1</a></li><li><a href="#part-2">Part 2</a></li><li><a href="#part-3">Part 3</a></li></ol>
+<ul class="showdown-toc"><li><a href="#part-1">Part 1</a></li><li><a href="#part-2">Part 2</a></li><li><a href="#part-3">Part 3</a></li></ul>
 <h3 id="part-1">Part 1</h3>
 <p>It was a nice day.</p>
 <h3 id="part-2">Part 2</h3>
@@ -13,7 +13,7 @@
 <p>Then it rained.</p>
 <h2 id="section-2">Section 2</h2>
 <p>Notice the section 2 header above is not included in the TOC of section 1? That's because each toc tag assumes it should stay in it's own section.</p>
-<ol class="showdown-toc"><li><a href="#part-1-1">Part 1</a></li><li><a href="#part-2-1">Part 2</a></li><li><a href="#part-3-1">Part 3</a></li></ol>
+<ul class="showdown-toc"><li><a href="#part-1-1">Part 1</a></li><li><a href="#part-2-1">Part 2</a></li><li><a href="#part-3-1">Part 3</a></li></ul>
 <h3 id="part-1-1">Part 1</h3>
 <h3 id="part-2-1">Part 2</h3>
 <h4 id="part-2a-1">Part 2A</h4>

--- a/test/fixtures/toc-ul-in-markdown/option.ts
+++ b/test/fixtures/toc-ul-in-markdown/option.ts
@@ -1,0 +1,1 @@
+export default { toc: [], opts: { listType: 'ul' } };


### PR DESCRIPTION
* The README shows `class="showdown-toc"`, but that output isn't produced. I've added the class so that designers can override the default styles.
* The plugin produces an ordered list. I created an options parameter that allows this to be overridden as an ordered list
* A lot of the supporting developer tools are outdated and husky was blowing on the git hook. I needed to remove this just to commit it to my local repository.
